### PR TITLE
NixOS: assign `aesmd` user the configured group

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1627857416,
-        "narHash": "sha256-AV0MsFVzbWI2MZbJ2j0kc8ooFLGSCZHuM9ipaWR9ds4=",
+        "lastModified": 1631785487,
+        "narHash": "sha256-VSKEvOtaY/roDxEHFxXh6GguOqqWCJZ3E06fBdKu8+I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aaf9676fbb7fb4570216ca1e189a3dc769d62c45",
+        "rev": "79c444b5bdeaba142d128afddee14c89ecf2a968",
         "type": "github"
       },
       "original": {

--- a/nixos/modules/sgx.nix
+++ b/nixos/modules/sgx.nix
@@ -97,6 +97,7 @@ in
         users.users.${cfgAesmd.user} = {
           description = "Intel Architectural Enclave Service Manager ";
           isSystemUser = true;
+          group = cfgAesmd.group;
           extraGroups = [
             cfgAesmd.provision.group
           ];


### PR DESCRIPTION
- flake.lock: Update
- nixos/aesmd: assign `aesmd` user the configured group
